### PR TITLE
Fix codecov configuration: change 'file:' to 'files:'

### DIFF
--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -46,5 +46,5 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Documentation


### PR DESCRIPTION
## Summary
- Updates codecov GitHub action configuration to use `files:` instead of deprecated `file:` parameter
- Affects workflow files in `.github/workflows/`

## Context
The codecov action has deprecated the `file:` parameter in favor of `files:` (plural). This change updates all workflow files to use the correct parameter name to avoid potential issues with future codecov action versions.

## Changes
- Replace `file: lcov.info` with `files: lcov.info` in all GitHub workflow files

## Testing
- [ ] Verify workflows still run successfully
- [ ] Confirm codecov uploads work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)