### PR TITLE
Fixed deprecated QuantumClifford parity_checks_x API in BPOTS tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.3.4 - dev
 
 - bump julia compat to 1.12
+- fix deprecated `parity_checks_x` API call in BP-OTS tests (now `parity_matrix_x`)
 
 ## v0.3.3 - 2025-04-15
 

--- a/test/test_bpots.jl
+++ b/test/test_bpots.jl
@@ -117,7 +117,7 @@ Tests syndrome matching
         # Generate toric code matrix with a smaller distance for testing
         d_test = 3
         println("Generating toric code matrix (d=$d_test)...")
-        H_toric = parity_checks_x(Toric(d_test, d_test))
+        H_toric = parity_matrix_x(Toric(d_test, d_test))
         
         # Test with reduced noise levels and iterations for faster testing
         noise_levels = [0.01, 0.05, 0.1]


### PR DESCRIPTION
While setting up this repository locally to explore the decoder architecture, I ran the
test suite and found that `test_bpots.jl` fails with an `UndefVarError` because
`parity_checks_x` was renamed to `parity_matrix_x` in modern QuantumClifford.jl (>0.9).

This is a one-line fix updating line 120 of `test/test_bpots.jl`:
- `parity_checks_x(Toric(d, d))` → `parity_matrix_x(Toric(d, d))`
