### PR TITLE
API consistency: generic batchdecode!, widen decode! for BPOTS, migrate BP off deprecated path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Make JET a conditional test dependency (only installed when `JET_TEST=true`)
 - bump julia compat to 1.12
 - fix deprecated `parity_checks_x` API call in BP-OTS tests (now `parity_matrix_x`)
+- Add generic `batchdecode!` fallback and widen `BPOTSDecoder` `decode!` to accept `AbstractVector`
+- Use `decode!` instead of deprecated `syndrome_decode!` in BP `batchdecode!`
 - Set up Documenter.jl docs page with API reference and decoder guides
 - Add docstrings to all public types and methods
 - Fix pre-existing docstring bugs (broken code blocks, undefined variables)

--- a/src/decoders/abstract_decoder.jl
+++ b/src/decoders/abstract_decoder.jl
@@ -7,3 +7,34 @@ Concrete decoders (e.g., [`BeliefPropagationDecoder`](@ref), [`BitFlipDecoder`](
 subtype `AbstractDecoder` and must implement [`decode!`](@ref).
 """
 abstract type AbstractDecoder end
+
+"""
+    batchdecode!(decoder::AbstractDecoder, syndromes, errors)
+
+Decode every column of `syndromes` with `decoder`, writing the guesses into
+`errors` column-by-column.
+
+This generic fallback works for any `AbstractDecoder` that implements
+[`decode!`](@ref).  Individual decoders may override it if a more efficient
+batch strategy exists.
+
+# Arguments
+- `decoder`: Any concrete `AbstractDecoder`.
+- `syndromes`: Matrix whose columns are the syndromes to decode.
+- `errors`: Pre-allocated matrix (same column count); overwritten with guesses.
+
+Returns `(errors, converged)` where `converged` is a `Vector{Bool}`.
+"""
+function batchdecode!(decoder::AbstractDecoder, syndromes, errors)
+    @assert size(syndromes, 2) == size(errors, 2)
+    num_trials = size(syndromes, 2)
+    converged = Vector{Bool}(undef, num_trials)
+
+    for i in axes(syndromes, 2)
+        guess, conv = decode!(decoder, syndromes[:, i])
+        converged[i] = conv
+        errors[:, i] = guess
+    end
+
+    return errors, converged
+end

--- a/src/decoders/abstract_decoder.jl
+++ b/src/decoders/abstract_decoder.jl
@@ -9,32 +9,40 @@ subtype `AbstractDecoder` and must implement [`decode!`](@ref).
 abstract type AbstractDecoder end
 
 """
-    batchdecode!(decoder::AbstractDecoder, syndromes, errors)
+    batchdecode!(decoder::AbstractDecoder, syndromes::AbstractMatrix, errors::AbstractMatrix, [converged::AbstractVector{Bool}])
 
-Decode every column of `syndromes` with `decoder`, writing the guesses into
-`errors` column-by-column.
+Decode each column of `syndromes` with `decoder`, writing the results into the
+corresponding column of `errors`.
 
-This generic fallback works for any `AbstractDecoder` that implements
-[`decode!`](@ref).  Individual decoders may override it if a more efficient
-batch strategy exists.
+This is the generic fallback for any `AbstractDecoder` that implements
+[`decode!`](@ref). Individual decoders can override it with a faster batch
+strategy.
 
 # Arguments
 - `decoder`: Any concrete `AbstractDecoder`.
 - `syndromes`: Matrix whose columns are the syndromes to decode.
-- `errors`: Pre-allocated matrix (same column count); overwritten with guesses.
+- `errors`: Pre-allocated matrix (same column count); overwritten with results.
+- `converged`: Optional pre-allocated boolean vector. When provided, the function runs with zero allocations.
 
-Returns `(errors, converged)` where `converged` is a `Vector{Bool}`.
+Returns `(errors, converged)`. The `converged[i]` is `true` if the decoder found
+an error estimate whose syndrome matches `syndromes[:, i]` within the iteration
+limit, and `false` otherwise.
 """
-function batchdecode!(decoder::AbstractDecoder, syndromes, errors)
+function batchdecode!(decoder::AbstractDecoder, syndromes::AbstractMatrix, errors::AbstractMatrix, converged::AbstractVector{Bool})
     @assert size(syndromes, 2) == size(errors, 2)
-    num_trials = size(syndromes, 2)
-    converged = Vector{Bool}(undef, num_trials)
+    @assert size(syndromes, 2) == length(converged)
 
-    for i in axes(syndromes, 2)
+    @views for i in axes(syndromes, 2)
         guess, conv = decode!(decoder, syndromes[:, i])
         converged[i] = conv
-        errors[:, i] = guess
+        errors[:, i] .= guess
     end
 
     return errors, converged
+end
+
+function batchdecode!(decoder::AbstractDecoder, syndromes::AbstractMatrix, errors::AbstractMatrix)
+    num_trials = size(syndromes, 2)
+    converged = Vector{Bool}(undef, num_trials)
+    return batchdecode!(decoder, syndromes, errors, converged)
 end

--- a/src/decoders/belief_propagation.jl
+++ b/src/decoders/belief_propagation.jl
@@ -230,8 +230,4 @@ function batchdecode!(decoder::BeliefPropagationDecoder, syndromes::AbstractMatr
   return errors, success
 end
 
-function batchdecode!(decoder::BeliefPropagationDecoder, syndromes::AbstractMatrix, errors::AbstractMatrix)
-  num_trials::Int = size(syndromes, 2)
-  success = Vector{Bool}(undef, num_trials)
-  return batchdecode!(decoder, syndromes, errors, success)
-end
+

--- a/src/decoders/belief_propagation.jl
+++ b/src/decoders/belief_propagation.jl
@@ -196,6 +196,9 @@ Scratch space allocations are done once and re-used for better performance
 * `decoder`: The Belief Propagation decoder configuration
 * `syndromes`: Syndrome matrix that contains batch syndromes
 * `errors`: Predefined error matrix that this function manipulates
+* `success`: Optional pre-allocated boolean vector. If provided, `batchdecode!` will execute with zero allocations.
+
+Returns `(errors, success)`. The `success` vector represents whether the decoder succeeded: its i-th element is `true` if the decoder found an error estimate whose syndrome matches the i-th input syndrome within the maximum number of iterations, and `false` otherwise.
 
 # Examples
 ```jldoctest
@@ -214,16 +217,21 @@ julia> syndromes = (H * errors) .% 2;
 julia> guesses, successes = batchdecode!(decoder, syndromes, zero(errors));
 ```
 """
-function batchdecode!(decoder::BeliefPropagationDecoder, syndromes, errors)
+function batchdecode!(decoder::BeliefPropagationDecoder, syndromes::AbstractMatrix, errors::AbstractMatrix, success::AbstractVector{Bool})
   @assert size(syndromes, 2) == size(errors, 2)
-  num_trials::Int = size(syndromes, 2)
-  success::AbstractVector{Bool} = zeros(num_trials)
+  @assert size(syndromes, 2) == length(success)
 
-  for i in axes(syndromes, 2)
+  @views for i in axes(syndromes, 2)
     guess, conv = decode!(decoder, syndromes[:, i])
     success[i] = conv
-    errors[:, i] = guess
+    errors[:, i] .= guess
   end
 
   return errors, success
+end
+
+function batchdecode!(decoder::BeliefPropagationDecoder, syndromes::AbstractMatrix, errors::AbstractMatrix)
+  num_trials::Int = size(syndromes, 2)
+  success = Vector{Bool}(undef, num_trials)
+  return batchdecode!(decoder, syndromes, errors, success)
 end

--- a/src/decoders/belief_propagation.jl
+++ b/src/decoders/belief_propagation.jl
@@ -220,9 +220,9 @@ function batchdecode!(decoder::BeliefPropagationDecoder, syndromes, errors)
   success::AbstractVector{Bool} = zeros(num_trials)
 
   for i in axes(syndromes, 2)
-    reset!(decoder)
-    success[i] = syndrome_decode!(decoder, decoder.scratch, syndromes[:, i])
-    errors[:, i] = decoder.scratch.err
+    guess, conv = decode!(decoder, syndromes[:, i])
+    success[i] = conv
+    errors[:, i] = guess
   end
 
   return errors, success

--- a/src/decoders/bpots_decoder.jl
+++ b/src/decoders/bpots_decoder.jl
@@ -197,7 +197,7 @@ end
 
 # # UPDATE CHECK TO VARIABLE MSG (Eq 2)  [μ^(ℓ)i→j = (-1)^s_i · 2 tanh^(-1)(∏(j'∈N(c_i)\{v_j}) tanh(1/2 ν^(ℓ-1)_j'→i))]
 # # Check node i evaluate the parity constraint based on all other connected variables and informs the variable j about what this implies for j's error status
-function update_check_to_variable!(decoder::BPOTSDecoder, state::BPOTSState, i::Int, j::Int, H::SparseMatrixCSC, syndrome::Vector{Bool})
+function update_check_to_variable!(decoder::BPOTSDecoder, state::BPOTSState, i::Int, j::Int, H::SparseMatrixCSC, syndrome::AbstractVector)
     # Compute product of tanh values from other variables
     prod_tanh = 1.0
     MAX_TANH = 0.99999  # For numerical stability
@@ -242,7 +242,7 @@ every `T` iterations to break out of trapping sets.
 Returns `(error_estimate, converged)`.
 """
 # DECODE (MAIN ALGORITHM)
-function decode!(decoder::BPOTSDecoder, syndrome::Vector{Bool})
+function decode!(decoder::BPOTSDecoder, syndrome::AbstractVector)
     state = decoder.scratch
     reset!(decoder)
     

--- a/src/decoders/iterative_bitflip.jl
+++ b/src/decoders/iterative_bitflip.jl
@@ -201,8 +201,4 @@ function batchdecode!(decoder::BitFlipDecoder, syndromes::AbstractMatrix, errors
   return errors, converged
 end
 
-function batchdecode!(decoder::BitFlipDecoder, syndromes::AbstractMatrix, errors::AbstractMatrix)
-  num_trials::Int = size(syndromes, 2)
-  converged = Vector{Bool}(undef, num_trials)
-  return batchdecode!(decoder, syndromes, errors, converged)
-end
+

--- a/src/decoders/iterative_bitflip.jl
+++ b/src/decoders/iterative_bitflip.jl
@@ -165,6 +165,9 @@ Scratch space allocations are done once and re-used for better performance
 * `decoder`: The Bit flip decoder configuration
 * `syndromes`: Syndrome matrix that contains batch syndromes
 * `errors`: Predefined error matrix that this function manipulates
+* `converged`: Optional pre-allocated boolean vector. If provided, `batchdecode!` will execute with zero allocations.
+
+Returns `(errors, converged)`. The `converged` vector represents whether the decoder succeeded: its i-th element is `true` if the decoder found an error estimate whose syndrome matches the i-th input syndrome within the maximum number of iterations, and `false` otherwise.
 
 # Examples
 ```jldoctest
@@ -183,18 +186,23 @@ julia> syndromes = (H * errors) .% 2;
 julia> guesses, successes = batchdecode!(decoder, syndromes, zero(errors));
 ```
 """
-function batchdecode!(decoder::BitFlipDecoder, syndromes, errors)
+function batchdecode!(decoder::BitFlipDecoder, syndromes::AbstractMatrix, errors::AbstractMatrix, converged::AbstractVector{Bool})
   @assert size(syndromes, 2) == size(errors, 2)
-  num_trials::Int = size(syndromes, 2)
-  converged::AbstractVector{Bool} = zeros(num_trials)
+  @assert size(syndromes, 2) == length(converged)
 
-  for i in axes(syndromes, 2)
+  @views for i in axes(syndromes, 2)
     reset!(decoder)
     guess, conv = decode!(decoder, syndromes[:, i])
     # guess, conv = syndrome_it_decode(decoder.sparse_H, syndromes[:, i], decoder.max_iters, decoder.scratch.err, decoder.scratch.votes)
     converged[i] = conv
-    errors[:, i] = guess
+    errors[:, i] .= guess
   end
 
   return errors, converged
+end
+
+function batchdecode!(decoder::BitFlipDecoder, syndromes::AbstractMatrix, errors::AbstractMatrix)
+  num_trials::Int = size(syndromes, 2)
+  converged = Vector{Bool}(undef, num_trials)
+  return batchdecode!(decoder, syndromes, errors, converged)
 end

--- a/test/test_bposd_decoder.jl
+++ b/test/test_bposd_decoder.jl
@@ -46,7 +46,24 @@ using LDPCDecoders
     return syn == (H * guess) .% 2
   end
 
+  """Test for batch BP-OSD decoder (uses generic batchdecode! from AbstractDecoder)"""
+  function test_bposd_decoder_batch()
+    H = LDPCDecoders.parity_check_matrix(1000, 10, 9)
+    per = 0.01
+    num_trials = 10
+    errors = rand(1000, num_trials) .< per
+    syndromes = (H * errors) .% 2
+    bposd = BeliefPropagationOSDDecoder(H, per, 100)
+    guesses, successes = batchdecode!(bposd, syndromes, zero(errors))
+    # OSD guarantees syndrome consistency even when exact decoding fails
+    for i in 1:num_trials
+      @test (H * guesses[:, i]) .% 2 == syndromes[:, i]
+    end
+    return true
+  end
+
   @test test_bposd_decoder()
   @test test_bposd_decoder_high_order()
   @test test_bposd_decoder_large_error_rate()
+  @test test_bposd_decoder_batch()
 end

--- a/test/test_bpots.jl
+++ b/test/test_bpots.jl
@@ -5,7 +5,7 @@ using Test
 using SparseArrays
 using Random
 using QuantumClifford.ECC
-import LDPCDecoders: BPOTSDecoder, BeliefPropagationDecoder, decode!, reset!
+import LDPCDecoders: BPOTSDecoder, BeliefPropagationDecoder, decode!, batchdecode!, reset!
 
 #= 
 Tests syndrome matching
@@ -134,5 +134,35 @@ Tests syndrome matching
         for result in performance_results
             @test result.success_rate >= 0.85
         end
+    end
+
+    @testset "Batch Decoding" begin
+        H = create_cycle_matrix(8)
+        decoder = BPOTSDecoder(H, 0.01, 100; T=9, C=3.0)
+
+        samples = 5
+        syndromes = hcat([generate_random_syndrome(H) for _ in 1:samples]...)
+        errors_buf = zeros(Int, size(H, 2), samples)
+
+        guesses, successes = batchdecode!(decoder, syndromes, errors_buf)
+
+        for i in 1:samples
+            decoded_syndrome = Bool.(mod.(H * guesses[:, i], 2))
+            @test decoded_syndrome == syndromes[:, i]
+        end
+    end
+
+    @testset "decode! accepts AbstractVector" begin
+        H = create_cycle_matrix(8)
+        decoder = BPOTSDecoder(H, 0.01, 100; T=9, C=3.0)
+
+        # BitVector is a subtype of AbstractVector, not Vector{Bool}
+        error = zeros(Bool, 8)
+        error[1:2] .= true
+        syndrome_bitvec = BitVector(mod.(H * error, 2))
+
+        guess, converged = decode!(decoder, syndrome_bitvec)
+        decoded_syndrome = Bool.(mod.(H * guess, 2))
+        @test decoded_syndrome == Vector{Bool}(syndrome_bitvec)
     end
 end


### PR DESCRIPTION
Following up on our June 1st discussion — this addresses the API consistency gaps in the decoder interface.

## What changed

### Generic `batchdecode!` on `AbstractDecoder`

`batchdecode!` was only defined for `BeliefPropagationDecoder` and `BitFlipDecoder`. Rather than copy-paste the same loop into `BeliefPropagationOSDDecoder` and `BPOTSDecoder`, I added a single generic fallback on `AbstractDecoder` in `abstract_decoder.jl`. BP-OSD, BP-OTS, and any future decoders pick it up automatically , they just need to implement `decode!`.

The existing BP and BitFlip methods still take priority via dispatch. They're now functionally identical to the generic, so they can go in a follow-up cleanup if we want.

### Widened `decode!` for `BPOTSDecoder` to `AbstractVector`

Every other decoder accepts `AbstractVector`, but `BPOTSDecoder` was locked to `Vector{Bool}`. Passing a `BitVector` would have thrown a `MethodError`. Widened both the public `decode!` signature and the internal `update_check_to_variable!` helper.

### Migrated BP `batchdecode!` off deprecated `syndrome_decode!`

BP's `batchdecode!` was the only thing still calling `syndrome_decode!` from `syndrome_bp_decoder.jl` (marked `# TODO: Deprecated, to be removed`). Switched it to call `decode!` directly — same algorithm, one fewer dependency, and cleaning up the deprecated file later won't require touching `batchdecode!`.

## Tests

- Batch decoding test for BP-OSD (exercises the generic `AbstractDecoder` fallback)
- Batch decoding test for BP-OTS (same)
- `decode!` accepts `AbstractVector` for BP-OTS (passes a `BitVector`)

All passing locally:

- `bp_decoder`: 5/5
- `bposd_decoder`: 14/14
- `bpots`: 26/26