### PR TITLE
Fix type instability in batchdecode! convergence vectors

### DIFF
--- a/src/decoders/belief_propagation.jl
+++ b/src/decoders/belief_propagation.jl
@@ -203,7 +203,7 @@ julia> sum((guesses[:,i] == errors[:,i] for i in 1:samples)) > 0.995*samples
 function batchdecode!(decoder::BeliefPropagationDecoder, syndromes, errors)
   @assert size(syndromes, 2) == size(errors, 2)
   num_trials::Int = size(syndromes, 2)
-  success::AbstractVector{Bool} = zeros(num_trials)
+  success = falses(num_trials)
 
   for i in axes(syndromes, 2)
     reset!(decoder)

--- a/src/decoders/iterative_bitflip.jl
+++ b/src/decoders/iterative_bitflip.jl
@@ -169,7 +169,7 @@ julia> sum((guesses[:,i] == errors[:,i] for i in 1:samples)) > 0.995*samples
 function batchdecode!(decoder::BitFlipDecoder, syndromes, errors)
   @assert size(syndromes, 2) == size(errors, 2)
   num_trials::Int = size(syndromes, 2)
-  converged::AbstractVector{Bool} = zeros(num_trials)
+  converged = falses(num_trials)
 
   for i in axes(syndromes, 2)
     reset!(decoder)


### PR DESCRIPTION
Both `BeliefPropagationDecoder` and `BitFlipDecoder` initialize their success vectors like this:

```julia
success::AbstractVector{Bool} = zeros(num_trials)
```

`zeros(n)` returns `Vector{Float64}`. The type annotation is ignored at runtime ;Julia doesn't coerce here , so we get a Float64 vector when we wanted Bool: takes more memory, no compiler optimization. Switching to `falses(num_trials)` fixes it; that actually returns a `BitVector`.

---

There's a related problem in BP's `BeliefPropagationScratchSpace.err`, which is `Vector{Float64}`. As a result, `decode!` hands back `0.0`/`1.0` floats for the error guess. That's the reason `belief_propagation_osd.jl` has the `Bool.(copy(bp_err))` workaround with the `# TODO why error is in Float in BP?` comment sitting next to it. BitFlip and BP-OTS both use `Int` and  BP is the odd one out.

I didn't touch this here because it cascades: the core scratch space struct, matrix multiply behavior, the deprecated `syndrome_bp_decoder.jl`, and the QuantumClifford extension downstream. Cleaner to tackle it once the deprecated files are gone rather than threading it through now. 