### PR TITLE
Remove resolved dev comments, dead code, and non-actionable TODOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Set up Documenter.jl docs page with API reference and decoder guides
 - Add docstrings to all public types and methods
 - Fix pre-existing docstring bugs (broken code blocks, undefined variables)
+- Clean up outdated developer comments and TODOs across the codebase
 
 ## v0.3.3 - 2025-04-15
 

--- a/src/decoders/belief_propagation.jl
+++ b/src/decoders/belief_propagation.jl
@@ -90,7 +90,7 @@ function reset!(bp_decoder::BeliefPropagationDecoder)
   bp_decoder
 end
 
-# TODO: Belief decoder type, syndrome, error -> should be modified
+
 
 """
 Function to decode given the parity check matrix, syndrome and error
@@ -118,7 +118,7 @@ julia> success
 true
 ```
 """
-function decode!(decoder::BeliefPropagationDecoder, syndrome::AbstractVector) # TODO check if casting to bitarrays helps with performance -- if it does, set up warnings to the user for cases where they have not done the casting
+function decode!(decoder::BeliefPropagationDecoder, syndrome::AbstractVector)
   reset!(decoder)
   rows::Vector{Int} = rowvals(decoder.sparse_H);
   rowsT::Vector{Int} = rowvals(decoder.sparse_HT);

--- a/src/decoders/bpots_decoder.jl
+++ b/src/decoders/bpots_decoder.jl
@@ -357,29 +357,3 @@ function decode!(decoder::BPOTSDecoder, syndrome::AbstractVector)
     
     return state.best_decisions, false
 end
-
-
-#=
-
-Added pre-allocated buffers to the BPOTSState struct instead of creating new arrays in each iteration
-    Added Π and Ω vectors for beliefs (previously created in each decode! call)
-    Added decisions and llrs vectors (previously created in each iteration)
-    Added best_decisions vector (previously created and copied)
-    Added check_result and int_check_result for syndrome checking
-
-Added Pre-computed Neighbor Lists
-    var_neighbors: Pre-computed lists of check nodes connected to each variable
-    check_neighbors: Pre-computed lists of variable nodes connected to each check
-This eliminated repeated calls to get_variable_neighbors() and get_check_neighbors(), which were creating new arrays on each call.
-
-Used .= for assignments instead of = or copy()
-Used fill!() to reset arrays rather than creating new ones
-Used mul!() for matrix multiplication instead of the * operator  
-    (Added an integer buffer for intermediate results, Applied modulo 2 operation explicitly to avoid Boolean conversion errors)
-    Since when you multiply a Boolean sparse matrix (decoder.sparse_H) with an integer vector (state.decisions), the result can be greater than 1, and trying bool(2) gives an error.
-
-Replaced findall() and argmin() with direct iteration ()
-
-Modified compute_beliefs! to update pre-allocated buffers
-
-=#

--- a/src/decoders/iterative_bitflip.jl
+++ b/src/decoders/iterative_bitflip.jl
@@ -193,7 +193,6 @@ function batchdecode!(decoder::BitFlipDecoder, syndromes::AbstractMatrix, errors
   @views for i in axes(syndromes, 2)
     reset!(decoder)
     guess, conv = decode!(decoder, syndromes[:, i])
-    # guess, conv = syndrome_it_decode(decoder.sparse_H, syndromes[:, i], decoder.max_iters, decoder.scratch.err, decoder.scratch.votes)
     converged[i] = conv
     errors[:, i] .= guess
   end


### PR DESCRIPTION
no logic changes or addition,just some cleanup done

so,through this,i have removed

- `bpots_decoder.jl` — Large `#= ... =#` block documenting optimizations already in the code (pre-allocated buffers, neighbor lists, in-place operations).For reference, the removed block contained:
'''Added pre-allocated buffers to the BPOTSState struct instead of creating new arrays in each iteration: Π and Ω vectors for beliefs, decisions and llrs vectors, best_decisions vector, check_result and int_check_result for syndrome checking.
Added Pre-computed Neighbor Lists (var_neighbors, check_neighbors). This eliminated repeated calls to get_variable_neighbors() and get_check_neighbors(), which were creating new arrays on each call.
Used .= for assignments instead of = or copy(). Used fill!() to reset arrays rather than creating new ones. Used mul!() for matrix multiplication instead of the * operator (added an integer buffer for intermediate results, applied modulo 2 operation explicitly to avoid Boolean conversion errors — since multiplying a Boolean sparse matrix with an integer vector can produce values > 1, and Bool(2) errors).
Replaced findall() and argmin() with direct iteration. Modified compute_beliefs! to update pre-allocated buffers.'''
- `iterative_bitflip.jl` — Commented-out `syndrome_it_decode(...)` call in `batchdecode!`. Replaced by `decode!` and never cleaned up. Dead code.
- `belief_propagation.jl` — Two TODOs that don't actually point anywhere:
  - `# TODO: Belief decoder type, syndrome, error -> should be modified` (no context from this)
  - Inline TODO on `decode!` about bitarray casting performance(more like an investigation note)
