### PR TITLE
Run JET in a dedicated test environment

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   # Enforces the update of a changelog file on every pull request 
   changelog:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - uses: dangoslen/changelog-enforcer@v3

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -16,7 +16,7 @@ env:
   PYTHON: ~
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - t=${{ matrix.threads }} - jet=${{ matrix.jet }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - t=${{ matrix.threads }} - tests=${{ matrix.test_args }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -26,12 +26,12 @@ jobs:
             arch: x64
             version: alpha
             threads: 2
-            jet: 'false'
+            test_args: general
           - os: ubuntu-latest
             arch: x64
             version: '1'
             threads: 2
-            jet: 'true'
+            test_args: jet
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/install-juliaup@v3
@@ -41,7 +41,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
-          test_args: ${{ matrix.jet == 'true' && 'jet' || '' }}
+          test_args: ${{ matrix.test_args }}
         env:
           JULIA_NUM_THREADS: ${{ matrix.threads }}
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -40,9 +40,10 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          test_args: ${{ matrix.jet == 'true' && 'jet' || '' }}
         env:
           JULIA_NUM_THREADS: ${{ matrix.threads }}
-          JET_TEST: ${{ matrix.jet }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Documentation
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "3c486d74-64b9-4c60-8b1a-13a564e77efb"
 authors = ["Krishna Praneet Gudipaty", "Stefan Krastanov", "QuantumSavory contributors"]
 version = "0.3.4-dev"
 
+[workspace]
+projects = ["test", "test/projects/jet"]
+
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -13,4 +13,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [compat]
+Documenter = "1"
+QuantumClifford = "0.10, 0.11"
 TestItemRunner = "0.2.3, 1"

--- a/test/projects/jet/Project.toml
+++ b/test/projects/jet/Project.toml
@@ -1,16 +1,14 @@
 [deps]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LDPCDecoders = "3c486d74-64b9-4c60-8b1a-13a564e77efb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-QuantumClifford = "0525e862-1e90-11e9-3e4d-1b39d7109de1"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+
+[sources]
+LDPCDecoders = {path = "../../.."}
 
 [compat]
 TestItemRunner = "0.2.3, 1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,14 @@
 # Optional test flags
-JET_flag = get(ENV, "JET_TEST", "") == "true"
+JET_flag = ARGS == ["jet"]
 
-JET_flag && @info "Running with JET tests."
-
-using Pkg
-JET_flag && Pkg.add("JET")
+if JET_flag
+  @info "Running JET tests in their dedicated test environment."
+  using Pkg
+  Pkg.activate(joinpath(@__DIR__, "projects", "jet"))
+  Pkg.instantiate()
+else
+  @info "Skipping JET tests -- pass `test_args=[\"jet\"]` to Pkg.test to enable them."
+end
 
 using TestItemRunner
 using LDPCDecoders

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,13 @@
 # Optional test flags
-JET_flag = ARGS == ["jet"]
+const JET_PROJECT = normpath(joinpath(@__DIR__, "projects", "jet"))
+const test_args = isempty(ARGS) ? ["general"] : ARGS
+const JET_flag = length(test_args) == 1 && startswith(only(test_args), "jet")
 
 if JET_flag
-  @info "Running JET tests in their dedicated test environment."
+  @info "Activating the dedicated JET test environment." project=JET_PROJECT
   using Pkg
-  Pkg.activate(joinpath(@__DIR__, "projects", "jet"))
+  Pkg.activate(JET_PROJECT)
   Pkg.instantiate()
-else
-  @info "Skipping JET tests -- pass `test_args=[\"jet\"]` to Pkg.test to enable them."
 end
 
 using TestItemRunner

--- a/test/test_doctests.jl
+++ b/test/test_doctests.jl
@@ -1,6 +1,7 @@
 @testitem "Doctests" tags=[:doctests] begin
 using Documenter
 using LDPCDecoders
+using StableRNGs
 
 ENV["LINES"] = 80    # for forcing `displaysize(io)` to be big enough
 ENV["COLUMNS"] = 80

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -5,7 +5,8 @@ using Test
 
 import LinearAlgebra, DelimitedFiles
 
-    rep = report_package("LDPCDecoders";
+    rep = report_package(LDPCDecoders;
+        target_modules=(LDPCDecoders,),
         ignored_modules=(
             AnyFrameModule(LinearAlgebra),
             AnyFrameModule(DelimitedFiles),
@@ -13,6 +14,5 @@ import LinearAlgebra, DelimitedFiles
         )
     )
     @show rep
-    @test length(JET.get_reports(rep)) <= 5
-    @test_broken length(JET.get_reports(rep)) == 0
+    @test length(JET.get_reports(rep)) == 0
 end


### PR DESCRIPTION
## Summary

- move JET into `test/projects/jet` and remove dynamic installation
- route JET through `test_args: jet` and use the module-based report API
- preload `StableRNGs` before Documenter captures doctest output in workspace-backed test environments
- require TestItemRunner 0.2.3 or 1.x in the ordinary and JET test environments
- skip documentation and changelog checks for Dependabot pull requests

## Validation

- fresh-depot Julia 1.12.6 CI-equivalent ordinary run: 61/61 tests pass
- exact TestItemRunner v0.2.3 / TestItems v0.1.1 ordinary run: 61/61 tests pass
- exact TestItemRunner v0.2.3 isolated JET route passes with no reports
- `gh act -n --validate`
- workflow YAML and TOML parse; `git diff --check`

## Strict downgrade follow-up

- explicitly bound Documenter to 1.x and QuantumClifford to 0.10/0.11 because the test suite uses APIs absent from their registry-minimum releases
- exact strict resolution selected Documenter 1.0.0, QuantumClifford 0.10.0, and TestItemRunner 0.2.3; 53/53 downgrade tests passed without re-resolution